### PR TITLE
Replaced pixmap entry with icon entries in spec file

### DIFF
--- a/Installer/dolphin-emu.spec
+++ b/Installer/dolphin-emu.spec
@@ -138,7 +138,8 @@ make %{?_smp_mflags} install DESTDIR="%{?buildroot}"
 %doc license.txt Readme.md
 %{_bindir}/%{name}
 %{_datadir}/%{name}
-%{_datadir}/pixmaps/dolphin-emu.xpm
+%{_datadir}/icons/hicolor/48x48/apps/%{name}.*
+%{_datadir}/icons/hicolor/scalable/apps/%{name}.*
 %{_datadir}/applications/%{name}.desktop
 %{_mandir}/man6/%{name}.*
 


### PR DESCRIPTION
It seems the pixmap was replaced by png and svg icons some time ago.
rpmbuild fails on the pixmap entry, so it needed to be updated.
